### PR TITLE
Add generators

### DIFF
--- a/internal/gir/pass/pass.go
+++ b/internal/gir/pass/pass.go
@@ -92,6 +92,13 @@ func (p *Pass) writeGo(r types.Repository, gotemp *template.Template, dir string
 		enums[fn] = append(enums[fn], temp)
 	}
 
+	constants := make(map[string][]types.ConstantTemplate)
+	for _, con := range ns.Constants {
+		fn := con.FilenameSafe()
+		files = append(files, fn)
+		constants[fn] = append(constants[fn], con.Template(ns.Name, p.Types))
+	}
+
 	records := make(map[string][]types.RecordTemplate)
 	recordLookup := make(map[string]bool)
 	for _, rec := range ns.Records {
@@ -332,6 +339,7 @@ func (p *Pass) writeGo(r types.Repository, gotemp *template.Template, dir string
 			Callbacks:  callbacks[fn],
 			Records:    records[fn],
 			Enums:      enums[fn],
+			Constants:  constants[fn],
 			Functions:  functions[fn],
 			Interfaces: interfaces[fn],
 			Classes:    classes[fn],

--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -174,6 +174,9 @@ type RecordTemplate struct {
 	// Doc is the documentation of the alias
 	Doc string
 
+	// Constructors is the slice of functions that create the class struct
+	Constructors []FuncTemplate
+
 	// Fields is the list of record fields
 	Fields []RecordField
 }

--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -345,6 +345,8 @@ type ClassTemplate struct {
 	Receivers []FuncTemplate
 	// Interfaces are receiver methods that are implemented because it needs to satisfy a certain interface
 	Interfaces []InterfaceTemplate
+	// Functions are the Go function declarations
+	Functions []FuncTemplate
 	// Signals are helpers for ConnectX receivers
 	Signals []SignalsTemplate
 }

--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -177,6 +177,9 @@ type RecordTemplate struct {
 	// Constructors is the slice of functions that create the class struct
 	Constructors []FuncTemplate
 
+	// Receivers is the slice of functions that have value receivers to the struct
+	Receivers []FuncTemplate
+
 	// Fields is the list of record fields
 	Fields []RecordField
 }

--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -202,6 +202,17 @@ type EnumTemplate struct {
 	Values []enumValues
 }
 
+type ConstantTemplate struct {
+	// Name is the name of the constant
+	Name string
+	// Doc is the documentation for the constant
+	Doc string
+	// Type is the Go type for the constant
+	Type string
+	// Values are the list of values for the constant
+	Value string
+}
+
 type funcRetTemplate struct {
 	// Raw is the raw value for the underlying purego function
 	Raw string
@@ -380,6 +391,8 @@ type TemplateArg struct {
 	Callbacks []CallbackTemplate
 	// Enums are enumerations declared as const ... .... = ....
 	Enums []EnumTemplate
+	// Constants are declared as const ... .... = ....
+	Constants []ConstantTemplate
 	// Functions are the Go function declarations
 	Functions []FuncTemplate
 	// Interfaces is the list of interfaces that this package implements

--- a/internal/gir/types/types.go
+++ b/internal/gir/types/types.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -331,6 +332,23 @@ type Constant struct {
 
 	InfoAttrs
 	InfoElements
+}
+
+func (c *Constant) Template(ns string, kinds KindMap) ConstantTemplate {
+	t := c.Type.Template(ns, kinds)
+	v := c.Value
+
+	switch t {
+	case "string":
+		v = fmt.Sprintf(`"%s"`, v)
+	}
+
+	return ConstantTemplate{
+		Name:  c.Name,
+		Doc:   c.Doc.StringSafe(),
+		Type:  t,
+		Value: v,
+	}
 }
 
 type Constructor struct {

--- a/templates/go
+++ b/templates/go
@@ -31,6 +31,10 @@ type {{.Name}} struct {
      {{end}}
 }
 
+func (x *{{.Name}}) GoPointer() uintptr {
+     return uintptr(unsafe.Pointer(x))
+}
+
 {{$outer := .}}
 
 {{range .Constructors -}}
@@ -41,6 +45,18 @@ var x{{.Name}}{{$outer.Name}} func({{conv .Args.Pure.Types}}) {{.Ret.Raw}}
 func {{.Name}}{{$outer.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
      {{.Ret.Preamble $NotGLib}}
      {{if .Ret.Value}}cret :={{end}}x{{.Name}}{{$outer.Name}}({{conv .Args.API.Call}})
+     {{.Ret.Fmt $NotGObject}}
+}
+{{end}}
+
+{{$outer := .}}
+{{range .Receivers -}}
+var x{{$outer.Name}}{{.Name}} func(uintptr {{convc .Args.Pure.Types}}) {{.Ret.Raw}}
+
+{{.Doc}}
+func (x *{{$outer.Name}}) {{.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
+     {{.Ret.Preamble $NotGLib}}
+     {{if .Ret.Value}}cret :={{end}}x{{$outer.Name}}{{.Name}}(x.GoPointer() {{convc .Args.API.Call}})
      {{.Ret.Fmt $NotGObject}}
 }
 {{end}}
@@ -216,9 +232,12 @@ func init() {
     {{end}}
 
     {{range .Records -}}
-    {{$cls := .}}
+    {{$rec := .}}
     {{range .Constructors -}}
-    core.PuregoSafeRegister(&x{{.Name}}{{$cls.Name}}, lib, "{{.CName}}")
+    core.PuregoSafeRegister(&x{{.Name}}{{$rec.Name}}, lib, "{{.CName}}")
+    {{end}}
+    {{range .Receivers -}}
+    core.PuregoSafeRegister(&x{{$rec.Name}}{{.Name}}, lib, "{{.CName}}")
     {{end}}
     {{end}}
 

--- a/templates/go
+++ b/templates/go
@@ -104,6 +104,15 @@ var {{.Namespace}}X{{.FullName}} func(uintptr {{convc .Args.Pure.Types}}) {{.Ret
 type {{.Name}} = {{.Value}}
 {{end}}
 
+{{if .Constants -}}
+const (
+{{range .Constants -}}
+	{{.Doc}}
+	{{.Name}} {{.Type}} = {{.Value}}
+{{end}}
+)
+{{end}}
+
 {{range .Enums -}}
 {{.Doc}}
 type {{.Name}} int

--- a/templates/go
+++ b/templates/go
@@ -190,6 +190,17 @@ func (x *{{$outer.Name}}) {{.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
 {{end}}
 {{end}}
 
+{{range .Functions -}}
+var x{{.Name}} func({{conv .Args.Pure.Types}}) {{.Ret.Raw}}
+
+{{.Doc}}
+func {{.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
+     {{.Ret.Preamble $NotGLib}}
+     {{if .Ret.Value}}cret := {{end}}x{{.Name}}({{conv .Args.API.Call}})
+     {{.Ret.Fmt $NotGObject}}
+}
+{{end}}
+
 {{end}}
 
 
@@ -218,6 +229,9 @@ func init() {
     {{end}}
     {{range .Receivers -}}
     core.PuregoSafeRegister(&x{{$cls.Name}}{{.Name}}, lib, "{{.CName}}")
+    {{end}}
+    {{range .Functions -}}
+    core.PuregoSafeRegister(&x{{.Name}}, lib, "{{.CName}}")
     {{end}}
     {{end}}
 

--- a/templates/go
+++ b/templates/go
@@ -30,6 +30,21 @@ type {{.Name}} struct {
      {{.Name}} {{.Type}}
      {{end}}
 }
+
+{{$outer := .}}
+
+{{range .Constructors -}}
+var x{{.Name}}{{$outer.Name}} func({{conv .Args.Pure.Types}}) {{.Ret.Raw}}
+
+
+{{.Doc}}
+func {{.Name}}{{$outer.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
+     {{.Ret.Preamble $NotGLib}}
+     {{if .Ret.Value}}cret :={{end}}x{{.Name}}{{$outer.Name}}({{conv .Args.API.Call}})
+     {{.Ret.Fmt $NotGObject}}
+}
+{{end}}
+
 {{end}}
 
 {{range .Interfaces -}}
@@ -188,6 +203,14 @@ func init() {
     {{range .Functions -}}
     core.PuregoSafeRegister(&x{{.Name}}, lib, "{{.CName}}")
     {{end}}
+
+    {{range .Records -}}
+    {{$cls := .}}
+    {{range .Constructors -}}
+    core.PuregoSafeRegister(&x{{.Name}}{{$cls.Name}}, lib, "{{.CName}}")
+    {{end}}
+    {{end}}
+
     {{range .Classes -}}
     {{$cls := .}}
     {{range .Constructors -}}
@@ -197,6 +220,7 @@ func init() {
     core.PuregoSafeRegister(&x{{$cls.Name}}{{.Name}}, lib, "{{.CName}}")
     {{end}}
     {{end}}
+
     {{range .Interfaces -}}
     {{range .Methods -}}
     core.PuregoSafeRegister(&{{.Namespace}}X{{.FullName}}, lib, "{{.CName}}")

--- a/templates/gobject
+++ b/templates/gobject
@@ -1,11 +1,9 @@
 package gobject
 
 import (
-	"os"
 	"reflect"
 
 	"github.com/jwijenbergh/purego"
-	"github.com/jwijenbergh/puregotk/internal/core"
 )
 
 type Ptr interface {
@@ -39,11 +37,11 @@ func (o Object) Cast(v Ptr) {
 }
 
 func (o Object) ConnectSignal(signal string, cb func()) uint32 {
-     return SignalConnect(o.GoPointer(), signal, purego.NewCallback(cb))
+	return SignalConnect(o.GoPointer(), signal, purego.NewCallback(cb))
 }
 
 func (o Object) DisconnectSignal(handler uint32) {
-     SignalHandlerDisconnect(&o, handler)
+	SignalHandlerDisconnect(&o, handler)
 }
 
 // NewCallback is an alias to purego.NewCallback
@@ -79,31 +77,3 @@ const (
 	TypeReservedBseLastVal        = 48 << 2
 	TypeReservedUserFirstVal      = 49 << 2
 )
-
-var xValueGetString func(*Value) string
-
-func (v *Value) String() string {
-	return xValueGetString(v)
-}
-
-var xValueGetInt func(*Value) int
-
-func (v *Value) Int() int {
-	return xValueGetInt(v)
-}
-
-var xValueUnset func(*Value)
-
-func (x *Value) Unset() {
-	xValueUnset(x)
-}
-
-func init() {
-	lib, err := purego.Dlopen(os.Getenv("PUREGOTK_GTK_PATH"), purego.RTLD_NOW|purego.RTLD_GLOBAL)
-	if err != nil {
-		panic(err)
-	}
-	core.PuregoSafeRegister(&xValueGetString, lib, "g_value_get_string")
-	core.PuregoSafeRegister(&xValueGetInt, lib, "g_value_get_int")
-	core.PuregoSafeRegister(&xValueUnset, lib, "g_value_unset")
-}


### PR DESCRIPTION
First I just wanted to say thanks for this project - the state of CGo compilation performance is sadly quite abysmal. Purego is a very interesting alternative approach.

This series significantly increases API coverage by adding generators for the following:

- Records
  - *Constructors*
  - *Methods*
- Classes
  - *Functions*
- *Constants*

---

The other significant change made here (10a808e50cdf574b7b029e341c65f7290faacdd9) is perhaps slightly more controversial, it does the following (from the commit msg):

## Add Ptr variants for callback APIs
This allows users to create reusable purego callbacks, rather than
allocating a new callback for each call. This is necessary for any
long-running application that needs to perform updates on the GUI thread
(e.g. via `glib.IdleAdd()`) since purego callbacks are never freed, and
it currently has a hard limit of 2000 callbacks created during the
lifetime of the application, after which purego panics.

Hopefully the use-case there is somewhat obvious, though I'm not in love with the way I implemented the generator for it. Without this change there was no way to write an application using the many callback APIs in GTK, since every invocation of a callback would register a new callback with purego, quickly resulting in a purego panic when it runs out of callback registers.

---

I apologise for the huge patchset here, I wasn't sure whether to try to send just the generator changes, to to include the resulting output too - in the end I decided it was probably best to keep the updated generated code paired with the generator changes that produced it.