### PR TITLE
Core: Allow callbacks to be re-used and unreferenced

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -48,4 +48,16 @@ func main() {
 	if err == nil {
 		os.WriteFile("v4/glib/more.go", data, 0o644)
 	}
+	data, err = os.ReadFile("templates/glib_sysv")
+	if err == nil {
+		os.WriteFile("v4/glib/more_sysv.go", data, 0o644)
+	}
+	data, err = os.ReadFile("templates/glib_windows")
+	if err == nil {
+		os.WriteFile("v4/glib/more_windows.go", data, 0o644)
+	}
+	data, err = os.ReadFile("templates/glib_other")
+	if err == nil {
+		os.WriteFile("v4/glib/more_other.go", data, 0o644)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/jwijenbergh/puregotk
 
 go 1.20
 
-require github.com/jwijenbergh/purego v0.0.0-20240105094719-439893e0402d
+require github.com/jwijenbergh/purego v0.0.0-20240126093400-70ff3a61df13
 
-require golang.org/x/sys v0.16.0 // indirect
+require golang.org/x/sys v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,4 @@
-github.com/jwijenbergh/purego v0.0.0-20230928085051-57b69bdc2564 h1:RjZ3zeAzTGd14apPGTVyOwF+L5o5eqyxAi+zUTaDh9E=
-github.com/jwijenbergh/purego v0.0.0-20230928085051-57b69bdc2564/go.mod h1:EtQVHFqUYxSUClPLQPCNz/R3m7egkBOxwZzIkufo7EA=
-github.com/jwijenbergh/purego v0.0.0-20240105094719-439893e0402d h1:5lsX/ps4lQvTx6V0BKfGdz0qEG6NoXVhIhlMFkGTi7M=
-github.com/jwijenbergh/purego v0.0.0-20240105094719-439893e0402d/go.mod h1:EtQVHFqUYxSUClPLQPCNz/R3m7egkBOxwZzIkufo7EA=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
-golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+github.com/jwijenbergh/purego v0.0.0-20240126093400-70ff3a61df13 h1:zpIcrUoZuJt2No2wCcyKaC5u8h8/aMsnKZufR8NVLF0=
+github.com/jwijenbergh/purego v0.0.0-20240126093400-70ff3a61df13/go.mod h1:EtQVHFqUYxSUClPLQPCNz/R3m7egkBOxwZzIkufo7EA=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -36,9 +36,13 @@ func (f *funcArgsTemplate) AddAPI(t string, n string, k Kind, ns string) {
 	if strings.ToLower(ns) == "gobject" {
 		gobjectNs = ""
 	}
+	glibNs := "glib."
+	if strings.ToLower(ns) == "glib" {
+		glibNs = ""
+	}
 	switch k {
 	case CallbackType:
-		c = fmt.Sprintf("purego.NewCallback(%s)", n)
+		c = fmt.Sprintf("%sNewCallback(%s)", glibNs, n)
 	case ClassesType:
 		if stars == 0 {
 			c = n

--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -43,6 +43,7 @@ func (f *funcArgsTemplate) AddAPI(t string, n string, k Kind, ns string) {
 	switch k {
 	case CallbackType:
 		c = fmt.Sprintf("%sNewCallback(%s)", glibNs, n)
+		t = "*" + t
 	case ClassesType:
 		if stars == 0 {
 			c = n

--- a/templates/glib
+++ b/templates/glib
@@ -1,14 +1,62 @@
 package glib
 
 import (
-       "fmt"
-       "github.com/jwijenbergh/puregotk/internal/core"
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/jwijenbergh/purego"
+	"github.com/jwijenbergh/puregotk/internal/core"
 )
 
+var callbacks = struct {
+	sync.RWMutex
+	refs map[uintptr]uintptr
+}{
+	refs: make(map[uintptr]uintptr),
+}
+
+// GetCallback retrives a callback reference by value.
+// Users should not need to call this.
+func GetCallback(cbPtr uintptr) (uintptr, bool) {
+	callbacks.RLock()
+	defer callbacks.RUnlock()
+	refPtr, ok := callbacks.refs[cbPtr]
+	return refPtr, ok
+}
+
+// SaveCallback saves a reference to the callback value.
+// Users should not need to call this.
+func SaveCallback(cbPtr uintptr, refPtr uintptr) {
+	callbacks.Lock()
+	callbacks.refs[cbPtr] = refPtr
+	callbacks.Unlock()
+}
+
+// UnrefCallbackValue unreferences the provided callback by reflect.value to free a purego slot
+func UnrefCallback(fn interface{}) error {
+	cbPtr := reflect.ValueOf(fn).Pointer()
+	refPtr, ok := GetCallback(cbPtr)
+	if !ok {
+		return purego.UnrefCallback(fn)
+	}
+	defer func() {
+		callbacks.Lock()
+		delete(callbacks.refs, cbPtr)
+		callbacks.Unlock()
+	}()
+	return purego.UnrefCallbackPtr(refPtr)
+}
+
+// NewCallback is an alias to purego.NewCallback
+func NewCallback(fn interface{}) uintptr {
+	return purego.NewCallback(fn)
+}
+
 func (e *Error) Error() string {
-     return fmt.Sprintf("Gtk reported an error with message: '%s', domain: '%v' and code: '%v'", e.MessageGo(), e.Domain, e.Code)
+	return fmt.Sprintf("Gtk reported an error with message: '%s', domain: '%v' and code: '%v'", e.MessageGo(), e.Domain, e.Code)
 }
 
 func (e *Error) MessageGo() string {
-     return core.GoString(e.Message)
+	return core.GoString(e.Message)
 }

--- a/templates/glib
+++ b/templates/glib
@@ -2,7 +2,6 @@ package glib
 
 import (
 	"fmt"
-	"reflect"
 	"sync"
 
 	"github.com/jwijenbergh/purego"
@@ -34,25 +33,12 @@ func SaveCallback(cbPtr uintptr, refPtr uintptr) {
 }
 
 // UnrefCallbackValue unreferences the provided callback by reflect.value to free a purego slot
+//
+// NOTE: Windows does not support unreferencing callbacks, so on that platform this operation is
+// a NOOP, callback memory is never freed, and there is a limit on maximum total callbacks.
+// See the purego documentation for further details.
 func UnrefCallback(fnPtr interface{}) error {
-	val := reflect.ValueOf(fnPtr)
-	if val.IsNil() {
-		return fmt.Errorf("function pointer must not be nil")
-	}
-	if val.Kind() != reflect.Ptr || val.Elem().Kind() != reflect.Func {
-		return fmt.Errorf("type must be a function pointer")
-	}
-	cbPtr := reflect.ValueOf(fnPtr).Pointer()
-	refPtr, ok := GetCallback(cbPtr)
-	if !ok {
-		return purego.UnrefCallbackFnPtr(fnPtr)
-	}
-	defer func() {
-		callbacks.Lock()
-		delete(callbacks.refs, cbPtr)
-		callbacks.Unlock()
-	}()
-	return purego.UnrefCallback(refPtr)
+	return unrefCallback(fnPtr)
 }
 
 // NewCallback is an alias to purego.NewCallback

--- a/templates/glib
+++ b/templates/glib
@@ -34,23 +34,30 @@ func SaveCallback(cbPtr uintptr, refPtr uintptr) {
 }
 
 // UnrefCallbackValue unreferences the provided callback by reflect.value to free a purego slot
-func UnrefCallback(fn interface{}) error {
-	cbPtr := reflect.ValueOf(fn).Pointer()
+func UnrefCallback(fnPtr interface{}) error {
+	val := reflect.ValueOf(fnPtr)
+	if val.IsNil() {
+		return fmt.Errorf("function pointer must not be nil")
+	}
+	if val.Kind() != reflect.Ptr || val.Elem().Kind() != reflect.Func {
+		return fmt.Errorf("type must be a function pointer")
+	}
+	cbPtr := reflect.ValueOf(fnPtr).Pointer()
 	refPtr, ok := GetCallback(cbPtr)
 	if !ok {
-		return purego.UnrefCallback(fn)
+		return purego.UnrefCallbackFnPtr(fnPtr)
 	}
 	defer func() {
 		callbacks.Lock()
 		delete(callbacks.refs, cbPtr)
 		callbacks.Unlock()
 	}()
-	return purego.UnrefCallbackPtr(refPtr)
+	return purego.UnrefCallback(refPtr)
 }
 
 // NewCallback is an alias to purego.NewCallback
-func NewCallback(fn interface{}) uintptr {
-	return purego.NewCallback(fn)
+func NewCallback(fnPtr interface{}) uintptr {
+	return purego.NewCallbackFnPtr(fnPtr)
 }
 
 func (e *Error) Error() string {

--- a/templates/glib_other
+++ b/templates/glib_other
@@ -1,0 +1,8 @@
+//go:build !windows && !darwin && !freebsd && (!linux || (!amd64 && !arm64))
+
+package glib
+
+// unrefCallback on unsupported on other platforms
+func unrefCallback(_ interface{}) error {
+	panic("glib.UnrefCallback is unsupported on this platform")
+}

--- a/templates/glib_sysv
+++ b/templates/glib_sysv
@@ -1,0 +1,31 @@
+//go:build darwin || freebsd || (linux && (amd64 || arm64))
+
+package glib
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/jwijenbergh/purego"
+)
+
+func unrefCallback(fnPtr interface{}) error {
+	val := reflect.ValueOf(fnPtr)
+	if val.IsNil() {
+		return fmt.Errorf("function pointer must not be nil")
+	}
+	if val.Kind() != reflect.Ptr || val.Elem().Kind() != reflect.Func {
+		return fmt.Errorf("type must be a function pointer")
+	}
+	cbPtr := reflect.ValueOf(fnPtr).Pointer()
+	refPtr, ok := GetCallback(cbPtr)
+	if !ok {
+		return purego.UnrefCallbackFnPtr(fnPtr)
+	}
+	defer func() {
+		callbacks.Lock()
+		delete(callbacks.refs, cbPtr)
+		callbacks.Unlock()
+	}()
+	return purego.UnrefCallback(refPtr)
+}

--- a/templates/glib_windows
+++ b/templates/glib_windows
@@ -1,0 +1,6 @@
+package glib
+
+// unrefCallback on Windows is a NOOP.
+func unrefCallback(_ interface{}) error {
+	return nil
+}

--- a/templates/go
+++ b/templates/go
@@ -185,19 +185,25 @@ func (c *{{.Name}}) SetGoPointer(ptr uintptr) {
 
 {{.Doc}}
 func (x *{{$outer.Name}}) Connect{{.Name}}(cb func({{$outer.Name}} {{convc .Args.API.Types}}) {{.Ret.Value}}) uint32 {
-     fcb := func(clsPtr uintptr {{convc .Args.Pure.Full}}) {{.Ret.Raw}} {
-         fa := {{$outer.Name}}{}
-         fa.Ptr = clsPtr
-         {{if .Ret.Class}}
-         {{.Name}}Cls := cb(fa {{convc .Args.Pure.Call}})
-         return {{.Name}}Cls.Ptr
-         {{else if .Ret.Value}}
-         return cb(fa {{convc .Args.Pure.Call}})
-         {{else}}
-         cb(fa {{convc .Args.Pure.Call}})
-         {{end}}
+     cbPtr := reflect.ValueOf(cb).Pointer()
+     cbRefPtr, ok := {{if $NotGLib}}glib.{{end}}GetCallback(cbPtr)
+     if !ok {
+          fcb := func(clsPtr uintptr {{convc .Args.Pure.Full}}) {{.Ret.Raw}} {
+               fa := {{$outer.Name}}{}
+               fa.Ptr = clsPtr
+               {{if .Ret.Class}}
+               {{.Name}}Cls := cb(fa {{convc .Args.Pure.Call}})
+               return {{.Name}}Cls.Ptr
+               {{else if .Ret.Value}}
+               return cb(fa {{convc .Args.Pure.Call}})
+               {{else}}
+               cb(fa {{convc .Args.Pure.Call}})
+               {{end}}
+          }
+          cbRefPtr = purego.NewCallback(fcb)
+          {{if $NotGLib}}glib.{{end}}SaveCallback(cbPtr, cbRefPtr)
      }
-     return {{if $NotGObject}}gobject.{{end}}SignalConnect(x.GoPointer(), "{{.CName}}", purego.NewCallback(fcb))
+     return {{if $NotGObject}}gobject.{{end}}SignalConnect(x.GoPointer(), "{{.CName}}", cbRefPtr)
 }
 {{end}}
 

--- a/templates/go
+++ b/templates/go
@@ -186,24 +186,25 @@ func (c *{{.Name}}) SetGoPointer(ptr uintptr) {
 {{.Doc}}
 func (x *{{$outer.Name}}) Connect{{.Name}}(cb *func({{$outer.Name}} {{convc .Args.API.Types}}) {{.Ret.Value}}) uint32 {
      cbPtr := uintptr(unsafe.Pointer(cb))
-     cbRefPtr, ok := {{if $NotGLib}}glib.{{end}}GetCallback(cbPtr)
-     if !ok {
-          fcb := func(clsPtr uintptr {{convc .Args.Pure.Full}}) {{.Ret.Raw}} {
-               fa := {{$outer.Name}}{}
-               fa.Ptr = clsPtr
-               cbFn := *cb
-               {{if .Ret.Class}}
-               {{.Name}}Cls := cbFn(fa {{convc .Args.Pure.Call}})
-               return {{.Name}}Cls.Ptr
-               {{else if .Ret.Value}}
-               return cbFn(fa {{convc .Args.Pure.Call}})
-               {{else}}
-               cbFn(fa {{convc .Args.Pure.Call}})
-               {{end}}
-          }
-          cbRefPtr = purego.NewCallback(fcb)
-          {{if $NotGLib}}glib.{{end}}SaveCallback(cbPtr, cbRefPtr)
+     if cbRefPtr, ok := {{if $NotGLib}}glib.{{end}}GetCallback(cbPtr); ok {
+          return {{if $NotGObject}}gobject.{{end}}SignalConnect(x.GoPointer(), "{{.CName}}", cbRefPtr)
      }
+
+     fcb := func(clsPtr uintptr {{convc .Args.Pure.Full}}) {{.Ret.Raw}} {
+          fa := {{$outer.Name}}{}
+          fa.Ptr = clsPtr
+          cbFn := *cb
+          {{if .Ret.Class}}
+          {{.Name}}Cls := cbFn(fa {{convc .Args.Pure.Call}})
+          return {{.Name}}Cls.Ptr
+          {{else if .Ret.Value}}
+          return cbFn(fa {{convc .Args.Pure.Call}})
+          {{else}}
+          cbFn(fa {{convc .Args.Pure.Call}})
+          {{end}}
+     }
+     cbRefPtr := purego.NewCallback(fcb)
+     {{if $NotGLib}}glib.{{end}}SaveCallback(cbPtr, cbRefPtr)
      return {{if $NotGObject}}gobject.{{end}}SignalConnect(x.GoPointer(), "{{.CName}}", cbRefPtr)
 }
 {{end}}

--- a/templates/go
+++ b/templates/go
@@ -184,20 +184,21 @@ func (c *{{.Name}}) SetGoPointer(ptr uintptr) {
 {{range .Signals -}}
 
 {{.Doc}}
-func (x *{{$outer.Name}}) Connect{{.Name}}(cb func({{$outer.Name}} {{convc .Args.API.Types}}) {{.Ret.Value}}) uint32 {
-     cbPtr := reflect.ValueOf(cb).Pointer()
+func (x *{{$outer.Name}}) Connect{{.Name}}(cb *func({{$outer.Name}} {{convc .Args.API.Types}}) {{.Ret.Value}}) uint32 {
+     cbPtr := uintptr(unsafe.Pointer(cb))
      cbRefPtr, ok := {{if $NotGLib}}glib.{{end}}GetCallback(cbPtr)
      if !ok {
           fcb := func(clsPtr uintptr {{convc .Args.Pure.Full}}) {{.Ret.Raw}} {
                fa := {{$outer.Name}}{}
                fa.Ptr = clsPtr
+               cbFn := *cb
                {{if .Ret.Class}}
-               {{.Name}}Cls := cb(fa {{convc .Args.Pure.Call}})
+               {{.Name}}Cls := cbFn(fa {{convc .Args.Pure.Call}})
                return {{.Name}}Cls.Ptr
                {{else if .Ret.Value}}
-               return cb(fa {{convc .Args.Pure.Call}})
+               return cbFn(fa {{convc .Args.Pure.Call}})
                {{else}}
-               cb(fa {{convc .Args.Pure.Call}})
+               cbFn(fa {{convc .Args.Pure.Call}})
                {{end}}
           }
           cbRefPtr = purego.NewCallback(fcb)

--- a/templates/gobject
+++ b/templates/gobject
@@ -3,7 +3,6 @@ package gobject
 import (
 	"reflect"
 
-	"github.com/jwijenbergh/purego"
 	"github.com/jwijenbergh/puregotk/v4/glib"
 )
 
@@ -43,11 +42,6 @@ func (o Object) ConnectSignal(signal string, cb *func()) uint32 {
 
 func (o Object) DisconnectSignal(handler uint32) {
 	SignalHandlerDisconnect(&o, handler)
-}
-
-// NewCallback is an alias to glib.NewCallback
-func NewCallback(fnPtr interface{}) uintptr {
-	return glib.NewCallback(fnPtr)
 }
 
 // types

--- a/templates/gobject
+++ b/templates/gobject
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/jwijenbergh/purego"
+	"github.com/jwijenbergh/puregotk/v4/glib"
 )
 
 type Ptr interface {
@@ -46,7 +47,7 @@ func (o Object) DisconnectSignal(handler uint32) {
 
 // NewCallback is an alias to purego.NewCallback
 func NewCallback(fn interface{}) uintptr {
-	return purego.NewCallback(fn)
+	return glib.NewCallback(fn)
 }
 
 // types

--- a/templates/gobject
+++ b/templates/gobject
@@ -37,17 +37,17 @@ func (o Object) Cast(v Ptr) {
 	v.SetGoPointer(o.GoPointer())
 }
 
-func (o Object) ConnectSignal(signal string, cb func()) uint32 {
-	return SignalConnect(o.GoPointer(), signal, purego.NewCallback(cb))
+func (o Object) ConnectSignal(signal string, cb *func()) uint32 {
+	return SignalConnect(o.GoPointer(), signal, glib.NewCallback(cb))
 }
 
 func (o Object) DisconnectSignal(handler uint32) {
 	SignalHandlerDisconnect(&o, handler)
 }
 
-// NewCallback is an alias to purego.NewCallback
-func NewCallback(fn interface{}) uintptr {
-	return glib.NewCallback(fn)
+// NewCallback is an alias to glib.NewCallback
+func NewCallback(fnPtr interface{}) uintptr {
+	return glib.NewCallback(fnPtr)
 }
 
 // types


### PR DESCRIPTION
Maintain a local callback cache and purego wrappers to support wrapped callbacks.

Move callback handling to glib to avoid import cycles since gobject already depends on glib.

Implements the design described in https://github.com/jwijenbergh/puregotk/pull/1#issuecomment-1874747415

Depends on accompanying PR against purego: https://github.com/jwijenbergh/purego/pull/1