### PR TITLE
Proposal: All class constructors should return their constructed types

### DIFF
--- a/internal/gir/pass/pass.go
+++ b/internal/gir/pass/pass.go
@@ -246,6 +246,7 @@ func (p *Pass) writeGo(r types.Repository, gotemp *template.Template, dir string
 
 		for i, c := range cls.Constructors {
 			name := util.SnakeToCamel(c.Name)
+			c.ReturnValue.AnyType.Type.Name = cls.Name
 			constructors[i] = types.FuncTemplate{
 				Name:  name,
 				CName: c.CIdentifier,


### PR DESCRIPTION
Currently working with the lib is a bit awkward due to the dance required by constructors returning unexpected types, in particular widget constructors returning `*gtk.Widget` instead of the type the constructor is named for.

For example in the current API:

```go
// Assume we've already created a *gtk.Box as parentBox, and some other *gtk.Widget as childWidget
// We wish to create a new *gtk.Viewport, set its child, and append the viewport to the parent

viewportWidget := gtk.NewViewport() // NewViewport returns *gtk.Widget, rather than the expected *gtk.Viewport
viewport := &gtk.Viewport{}
viewportWidget.Cast(viewport) // We need to cast to the correct type to use its methods
viewport.SetChild(childWidget)
parentBox.Append(viewportWidget) // But we still typically need the underlying widget, so we need to keep both around
```

If instead we return the expected type, because it already embeds gtk.Widget, this is much cleaner:

```go
viewport := gtk.NewViewport() // NewViewport returns *gtk.Viewport, which embeds gtk.Widget
viewport.SetChild(childWidget)
parentBox.Append(&viewport.Widget)
```

Drastically friendlier to work with, and because class types already embed their ancestors, the returned object provides access to all methods from the composed types on one object, and the ancestor types can be passed to any function that needs them by virtue of the pointer being set on the earliest ancestor (nice work btw, makes things very neat).

Obviously this would be a breaking change, but I think the usability benefits are well worth it.

As a quick hack to test I made the change in this PR, which unless I'm missing something ought be valid for all class constructors, and have been testing locally with no issues after migrating my consumer code to use the new API. With the change to make this work seeming so trivial though, I wonder if there was a reaon I'm not grokking that the current API was left standing.