### PR TITLE
Gir + Templates: Generate more Go friendly constructor names

### DIFF
--- a/internal/gir/pass/pass.go
+++ b/internal/gir/pass/pass.go
@@ -109,9 +109,8 @@ func (p *Pass) writeGo(r types.Repository, gotemp *template.Template, dir string
 		fn := rec.FilenameSafe()
 		files = append(files, fn)
 		for i, c := range rec.Constructors {
-			name := util.SnakeToCamel(c.Name)
 			constructors[i] = types.FuncTemplate{
-				Name:  name,
+				Name:  util.ConstructorName(c.Name, rec.Name),
 				CName: c.CIdentifier,
 				Doc:   c.Doc.StringSafe(),
 				Args:  c.Parameters.Template(ns.Name, "", p.Types, c.Throws),
@@ -245,10 +244,9 @@ func (p *Pass) writeGo(r types.Repository, gotemp *template.Template, dir string
 		files = append(files, fn)
 
 		for i, c := range cls.Constructors {
-			name := util.SnakeToCamel(c.Name)
 			c.ReturnValue.AnyType.Type.Name = cls.Name
 			constructors[i] = types.FuncTemplate{
-				Name:  name,
+				Name:  util.ConstructorName(c.Name, cls.Name),
 				CName: c.CIdentifier,
 				Doc:   c.Doc.StringSafe(),
 				Args:  c.Parameters.Template(ns.Name, "", p.Types, c.Throws),

--- a/internal/gir/util/util.go
+++ b/internal/gir/util/util.go
@@ -91,3 +91,18 @@ func ConvertArgsComma(a []string) string {
 	}
 	return ", " + strings.Join(a, ", ")
 }
+
+// ConstructorName returns a Go friendly constructor name given the raw constructor name `name` and the class/record name `outer`
+func ConstructorName(name string, outer string) string {
+	cname := SnakeToCamel(name)
+	// construct the final constructor name
+	// for example if we have gtk_builder
+	// gtk_builder_new_from_file
+	// cname will be NewFromFile
+	// we convert it to NewBuilderFromFile
+	if strings.HasPrefix(cname, "New") {
+		return "New" + outer + cname[3:]
+	}
+	// the default is just a concatenation if the constructor doesn't start with New
+	return outer + cname
+}

--- a/templates/go
+++ b/templates/go
@@ -35,13 +35,13 @@ func (x *{{.Name}}) GoPointer() uintptr {
 {{$outer := .}}
 
 {{range .Constructors -}}
-var x{{.Name}}{{$outer.Name}} func({{conv .Args.Pure.Types}}) {{.Ret.Raw}}
+var x{{.Name}} func({{conv .Args.Pure.Types}}) {{.Ret.Raw}}
 
 
 {{.Doc}}
-func {{.Name}}{{$outer.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
+func {{.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
      {{.Ret.Preamble $NotGLib}}
-     {{if .Ret.Value}}cret :={{end}}x{{.Name}}{{$outer.Name}}({{conv .Args.API.Call}})
+     {{if .Ret.Value}}cret :={{end}}x{{.Name}}({{conv .Args.API.Call}})
      {{.Ret.Fmt $NotGObject}}
 }
 {{end}}
@@ -150,13 +150,13 @@ func {{.Name}}NewFromInternalPtr(ptr uintptr) *{{.Name}} {
 }
 
 {{range .Constructors -}}
-var x{{.Name}}{{$outer.Name}} func({{conv .Args.Pure.Types}}) {{.Ret.Raw}}
+var x{{.Name}} func({{conv .Args.Pure.Types}}) {{.Ret.Raw}}
 
 
 {{.Doc}}
-func {{.Name}}{{$outer.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
+func {{.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
      {{.Ret.Preamble $NotGLib}}
-     {{if .Ret.Value}}cret :={{end}}x{{.Name}}{{$outer.Name}}({{conv .Args.API.Call}})
+     {{if .Ret.Value}}cret :={{end}}x{{.Name}}({{conv .Args.API.Call}})
      {{.Ret.Fmt $NotGObject}}
 }
 {{end}}
@@ -240,7 +240,7 @@ func init() {
     {{range .Records -}}
     {{$rec := .}}
     {{range .Constructors -}}
-    core.PuregoSafeRegister(&x{{.Name}}{{$rec.Name}}, lib, "{{.CName}}")
+    core.PuregoSafeRegister(&x{{.Name}}, lib, "{{.CName}}")
     {{end}}
     {{range .Receivers -}}
     core.PuregoSafeRegister(&x{{$rec.Name}}{{.Name}}, lib, "{{.CName}}")
@@ -250,7 +250,7 @@ func init() {
     {{range .Classes -}}
     {{$cls := .}}
     {{range .Constructors -}}
-    core.PuregoSafeRegister(&x{{.Name}}{{$cls.Name}}, lib, "{{.CName}}")
+    core.PuregoSafeRegister(&x{{.Name}}, lib, "{{.CName}}")
     {{end}}
     {{range .Receivers -}}
     core.PuregoSafeRegister(&x{{$cls.Name}}{{.Name}}, lib, "{{.CName}}")


### PR DESCRIPTION
Previously we just added the snake case of the constructor name + the record/class name. This leads to confusing names (old -> new):

gtk.NewFromStringBuilder -> gtk.NewBuilderFromString
gdkpixbuf.NewFromFilePixbuf -> gdkpixbuf.NewPixbufFromFile

Now we just check if it begins with New and if so add the class/record name directly after "New"

cc @pdf 