### PR TITLE
Allow GoPointer to return nil

### DIFF
--- a/templates/go
+++ b/templates/go
@@ -91,6 +91,9 @@ type {{.Name}}Base struct {
 }
 
 func (x *{{.Name}}Base) GoPointer() uintptr {
+     if x == nil {
+         return 0
+     }
      return x.Ptr
 }
 
@@ -210,6 +213,9 @@ func (x *{{$outer.Name}}) {{.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
 {{end}}
 
 func (c *{{.Name}}) GoPointer() uintptr {
+     if c == nil {
+         return 0
+     }
      return c.Ptr
 }
 


### PR DESCRIPTION
Various different functions around GTK allow accepting null pointers. Unfortunately, in the available GIR specs, there is no way to determine if a argument can or can't be null; but in the official documentation, for example in [`adw_dialog_present`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.7/method.Dialog.present.html), the second argument can be NULL as written, but is not mentioned in the GIR spec.

Partially solves accepting nil arguments, some functions also accept nil strings, which would require a middle-man to allow the string "`%NULL%`" to be interpreted as a nil pointer.