### PR TITLE
Add support for nullable callbacks

### DIFF
--- a/internal/gir/pass/pass.go
+++ b/internal/gir/pass/pass.go
@@ -63,6 +63,21 @@ func (p *Pass) collectTypes(r types.Repository) {
 	for _, inter := range ns.Interfaces {
 		p.Types.Add(ns.Name, inter.Name, types.InterfacesType, inter)
 	}
+	for _, alias := range ns.Aliases {
+		// Check what the alias points to and use the same type
+		aliasTarget := alias.Type.Name
+		if aliasTarget != "" {
+			targetKind := p.Types.Kind(ns.Name, aliasTarget)
+			if targetKind != types.UnknownType {
+				p.Types.Add(ns.Name, alias.Name, targetKind, alias)
+			} else {
+				// If we don't know the target type yet, default to alias type
+				p.Types.Add(ns.Name, alias.Name, types.AliasType, alias)
+			}
+		} else {
+			p.Types.Add(ns.Name, alias.Name, types.AliasType, alias)
+		}
+	}
 }
 
 // First does a "first pass" meaning it collects basic type information for all the repositories

--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -29,7 +29,7 @@ type funcArgsTemplate struct {
 	API argsTemplate
 }
 
-func (f *funcArgsTemplate) AddAPI(t string, n string, k Kind, ns string) {
+func (f *funcArgsTemplate) AddAPI(t string, n string, k Kind, ns string, nullable bool) {
 	c := n
 	stars := strings.Count(t, "*")
 	gobjectNs := "gobject."
@@ -42,7 +42,11 @@ func (f *funcArgsTemplate) AddAPI(t string, n string, k Kind, ns string) {
 	}
 	switch k {
 	case CallbackType:
-		c = fmt.Sprintf("%sNewCallback(%s)", glibNs, n)
+		if nullable {
+			c = fmt.Sprintf("%sNewCallbackNullable(%s)", glibNs, n)
+		} else {
+			c = fmt.Sprintf("%sNewCallback(%s)", glibNs, n)
+		}
 		t = "*" + t
 	case ClassesType:
 		if stars == 0 {
@@ -133,7 +137,7 @@ func (f *funcArgsTemplate) Add(p Parameter, ins string, ns string, kinds KindMap
 	// Get a suitable variable name
 	varName := p.VarName()
 
-	f.AddAPI(goType, varName, kind, ns)
+	f.AddAPI(goType, varName, kind, ns, p.Nullable)
 	f.AddPure(goType, varName, kind)
 }
 

--- a/templates/glib
+++ b/templates/glib
@@ -2,6 +2,7 @@ package glib
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/jwijenbergh/purego"
@@ -44,6 +45,16 @@ func UnrefCallback(fnPtr interface{}) error {
 // NewCallback is an alias to purego.NewCallback
 func NewCallback(fnPtr interface{}) uintptr {
 	return purego.NewCallbackFnPtr(fnPtr)
+}
+
+// NewCallbackNullable is an alias to purego.NewCallback that returns a null pointer for null functions
+func NewCallbackNullable(fn interface{}) uintptr {
+	val := reflect.ValueOf(fn)
+	if val.IsNil() {
+		return 0
+	}
+
+	return NewCallback(fn)
 }
 
 func (e *Error) Error() string {


### PR DESCRIPTION
Right now, the generated code isn't aware of whether an argument is marked as nullable in a GIR file (see for example the accumulator callback for registering signals: https://github.com/pojntfx/puregotk/blob/add-nullable-callbacks/internal/gir/spec/GObject-2.0.gir#L24817-L24826). Usually this can be "fixed" but just implementing empty functions, but in some cases, such as when registering signals, the arguments - mostly callbacks - need to actually be `NULL` or things won't work as expected, for example when registering signals with the function above. Right now, that's not possible - `purego.NewCallback` will panic with `purego: function must not be nil`.

To fix this, this PR adds a new helper, `NewCallbackNullable`. If an argument is a callback and marked as nullable, this new helper is used, which simply returns a NULL pointer in case the callback function that's being passed in is `nil`. Existing, non-nullable fields will still return `purego: function must not be nil` if a `nil` function is passed in incorrectly. I verified everything works correctly in my test repository, where I use it for creating signals when subclassing: https://github.com/pojntfx/senbara/blob/main/senbara-gtk/src/senbara-gtk.go

This doesn't lead to any breaking changes in the externally exposed API; I re-ran `./gen.sh` to verify.