### PR TITLE
Use pointers for `out` parameters

### DIFF
--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -47,7 +47,7 @@ func (f *funcArgsTemplate) AddAPI(t string, n string, k Kind, ns string, nullabl
 			// For primitive Go types we need to manually add the *
 			t = "*" + t
 		}
-		c = fmt.Sprintf("uintptr(unsafe.Pointer(%s))", n)
+		c = n
 	} else {
 		switch k {
 		case CallbackType:
@@ -96,14 +96,12 @@ func (f *funcArgsTemplate) AddPure(t string, n string, k Kind, isOut bool) {
 	stars := strings.Count(t, "*")
 
 	if isOut {
-		// Out parameters are always pointers in C, so we can use uintptr for the type
-		goPointerType := t
+		// Out parameters are always pointers in C
 		if stars == 0 {
 			// For primitive Go types we need to manually add the *
-			goPointerType = "*" + t
+			t = "*" + t
 		}
-		t = "uintptr"
-		c = fmt.Sprintf("(%s)(unsafe.Pointer(%s))", goPointerType, n)
+		c = n
 	} else {
 		switch k {
 		case RecordsType:


### PR DESCRIPTION
Right now, parameters with `direction="out"` get generated as regular parameters passed by value, for example like so:

```go
var x, y float64
drag.GetStartPoint(x, y) 
```

Ofc, in the example above `x` and `y` always stay zero. This PR changes the generator to instead render pointers for those parameters, like so:

```go
var x, y float64
drag.GetStartPoint(&x, &y)
```

`x` and `y` now get set to the actual value. Noticed this while working on [Sessions](https://github.com/pojntfx/sessions/) - the dial widget wouldn't pick up the handle from the starting position, but rather from the very start.

I've also prepared a secondary branch to see how the changes look like when generated: https://github.com/pojntfx/puregotk/tree/fix-out-param-types-gen