### PR TITLE
Add Flatpak application library path to defaults

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -29,14 +29,16 @@ func PuregoSafeRegister(fptr interface{}, libs []uintptr, name string) {
 // paths to where the shared object files should be located
 // this is unique per architecture
 // Debian/Ubuntu has it split into specific arch folder, Fedora is just /usr/lib64
+// Flatpak uses /app/lib for application libraries and runtimes don't vendor `pkg-config` as the fallback
 // see:
 // https://fedora.pkgs.org/38/fedora-x86_64/gtk4-4.10.1-1.fc38.x86_64.rpm.html
 // https://fedora.pkgs.org/38/fedora-aarch64/gtk4-4.10.1-1.fc38.aarch64.rpm.html
 // https://ubuntu.pkgs.org/23.04/ubuntu-main-amd64/libgtk-4-1_4.10.1+ds-2ubuntu1_amd64.deb.html
 // https://ubuntu.pkgs.org/23.04/ubuntu-main-arm64/libgtk-4-1_4.10.1+ds-2ubuntu1_arm64.deb.html
+// https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html (see --libdir)
 var paths = map[string][]string{
-	"amd64": {"/usr/lib/x86_64-linux-gnu/", "/usr/lib64/", "/usr/lib/"},
-	"arm64": {"/usr/lib/aarch64-linux-gnu/", "/usr/lib64/", "/usr/lib/"},
+	"amd64": {"/app/lib/", "/usr/lib/x86_64-linux-gnu/", "/usr/lib64/", "/usr/lib/"},
+	"arm64": {"/app/lib/", "/usr/lib/aarch64-linux-gnu/", "/usr/lib64/", "/usr/lib/"},
 }
 
 // names is a lookup from library names to shared object filenames


### PR DESCRIPTION
When you're trying to use a `puregotk`-based GObject library in a Flatpak as a dependency based on the current `main` branch like so:

```json
{
  "id": "com.pojtinger.felicitas.SenbaraGnomeNeo",
  "runtime": "org.gnome.Platform",
  "runtime-version": "49",
  "sdk": "org.gnome.Sdk",
  "sdk-extensions": ["org.freedesktop.Sdk.Extension.golang"],
  "command": "senbara-gnome-neo",
  "build-options": {
    "append-path": "/usr/lib/sdk/golang/bin",
    "build-args": ["--filesystem=home"]
  },
  "finish-args": [
    "--socket=wayland",
    "--socket=fallback-x11",
    "--share=ipc",
    "--device=dri"
  ],
  "modules": [
    {
      "name": "senbaragtk",
      "buildsystem": "meson",
      "sources": [
        { "type": "dir", "path": "../senbara-gtk/" },
        "senbaragtk.go.mod.json"
      ]
    },
    {
      "name": "senbaragnomeneo",
      "buildsystem": "meson",
      "sources": [{ "type": "dir", "path": "." }, "go.mod.json"]
    }
  ]
}
```

You get this error when trying to run it:

```shell
pkg-config, failed with: exec: "pkg-config": executable file not found in $PATH and stderr: 
panic: Path for library: senbaragtk not found. Please set the path to this library shared object file manually with env variable: PUREGOTK_SENBARAGTK_PATH or PUREGOTK_LIB_FOLDER. Or make sure pkg-config is setup correctly
```

Setting `PUREGOTK_LIB_FOLDER` to `/app/lib` is one option to fix this, but I'd argue that Flatpak is a common enough environment these days that it makes sense to add this as a default just like we do for major distros already. This PR does just that.

See https://github.com/pojntfx/senbara/blob/main/senbara-gnome-neo/com.pojtinger.felicitas.SenbaraGnomeNeo.json for an example of this in action.