### PR TITLE
Convert `uintptr` to Go strings when calling Go callbacks from C

### DIFF
--- a/internal/gir/types/template.go
+++ b/internal/gir/types/template.go
@@ -18,6 +18,11 @@ type argsTemplate struct {
 	Call []string
 
 	Full []string
+
+	// CallCToGo are the variables as given in a C-to-Go callback call
+	CallCToGo []string
+
+	FullCToGo []string
 }
 
 type funcArgsTemplate struct {
@@ -140,6 +145,16 @@ func (f *funcArgsTemplate) AddPure(t string, n string, k Kind, isOut bool) {
 	f.Pure.Types = append(f.Pure.Types, t)
 	f.Pure.Call = append(f.Pure.Call, c)
 	f.Pure.Full = append(f.Pure.Full, n+" "+t)
+
+	// For C-to-Go callbacks, purego doesn't automatically convert strings, we need to manually convert them with GoString
+	cToGoType := t
+	cToGoCall := c
+	if t == "string" {
+		cToGoType = "uintptr"
+		cToGoCall = fmt.Sprintf("core.GoString(%s)", n)
+	}
+	f.Pure.FullCToGo = append(f.Pure.FullCToGo, n+" "+cToGoType)
+	f.Pure.CallCToGo = append(f.Pure.CallCToGo, cToGoCall)
 }
 
 func (f *funcArgsTemplate) Add(p Parameter, ins string, ns string, kinds KindMap) {

--- a/templates/go
+++ b/templates/go
@@ -11,6 +11,7 @@ package {{.PkgName}}
 {{end}}
 {{ $NeedsUnsafe := or .Records $HasSignals }}
 {{ $NeedsPurego := or .NeedsInit $HasSignals }}
+{{ $NeedsCore := or .NeedsInit $HasSignals }}
 {{ $AnyImports := or .NeedsInit .Records $HasSignals }}
 
 {{if $AnyImports}}
@@ -24,7 +25,7 @@ import (
 {{- if $NeedsPurego}}
 	"github.com/jwijenbergh/purego"
 {{- end}}
-{{- if .NeedsInit}}
+{{- if $NeedsCore}}
 	"github.com/jwijenbergh/puregotk/pkg/core"
 {{- end}}
 )
@@ -90,12 +91,12 @@ func (x *{{$outer.Name}}) {{.Name}}({{conv .Args.API.Full}}) {{.Ret.Return}} {
      if cb == nil {
           x.x{{.Name}} = 0
      } else {
-          x.x{{.Name}} = purego.NewCallback(func({{conv .Args.Pure.Full}}) {{.Ret.Raw}} {
-               {{if .Ret.Value}}{{if .Ret.Class}}ret := cb({{convcb .Args.Pure.Call}})
+          x.x{{.Name}} = purego.NewCallback(func({{conv .Args.Pure.FullCToGo}}) {{.Ret.Raw}} {
+               {{if .Ret.Value}}{{if .Ret.Class}}ret := cb({{convcb .Args.Pure.CallCToGo}})
                if ret == nil {
                     return 0
                }
-               return ret.GoPointer(){{else}}return cb({{convcb .Args.Pure.Call}}){{end}}{{else}}cb({{convcb .Args.Pure.Call}}){{end}}
+               return ret.GoPointer(){{else}}return cb({{convcb .Args.Pure.CallCToGo}}){{end}}{{else}}cb({{convcb .Args.Pure.CallCToGo}}){{end}}
           })
      }
 }
@@ -333,17 +334,17 @@ func (x *{{$outer.Name}}) Connect{{.Name}}(cb *func({{$outer.Name}} {{convc .Arg
           return {{if $NotGObject}}gobject.{{end}}SignalConnect(x.GoPointer(), "{{.CName}}", cbRefPtr)
      }
 
-     fcb := func(clsPtr uintptr {{convc .Args.Pure.Full}}) {{.Ret.Raw}} {
+     fcb := func(clsPtr uintptr {{convc .Args.Pure.FullCToGo}}) {{.Ret.Raw}} {
           fa := {{$outer.Name}}{}
           fa.Ptr = clsPtr
           cbFn := *cb
           {{if .Ret.Class}}
-          {{.Name}}Cls := cbFn(fa {{convc .Args.Pure.Call}})
+          {{.Name}}Cls := cbFn(fa {{convc .Args.Pure.CallCToGo}})
           return {{.Name}}Cls.Ptr
           {{else if .Ret.Value}}
-          return cbFn(fa {{convc .Args.Pure.Call}})
+          return cbFn(fa {{convc .Args.Pure.CallCToGo}})
           {{else}}
-          cbFn(fa {{convc .Args.Pure.Call}})
+          cbFn(fa {{convc .Args.Pure.CallCToGo}})
           {{end}}
      }
      cbRefPtr := purego.NewCallback(fcb)


### PR DESCRIPTION
Right now, we don't convert the raw pointers back to the Go strings when we call a Go callback from C. This works the other way around (since `purego` converts strings automatically in that case), but not when calling Go code from C code. That causes dialog callbacks to always get passed empty strings for the `reason`:

```go
connectAlertDialogResponse(confirm, func(response string) {
					if response == "import" { // `response` will always be `""`
```

Same with settings `ConnectChanged` callbacks:

```go
connectSettingsChanged(settings, func(key string) {
			switch key { // `key` will always be ""
```

This PR extends the conversion rules to manually convert strings to fix this.