### PR TITLE
Add migration notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Moved to Codeberg
+
+This project has moved to [Codeberg](https://codeberg.org/puregotk/puregotk). This GitHub repository is no longer actively maintained.
+
+---
+
 # Puregotk
 
 > **_NOTE:_**  This library is currently expiremental and needs thorough testing. Some APIs might be incorrectly exposed


### PR DESCRIPTION
This adds a migration notice to the README of the GitHub repo so that people go to Codeberg instead.

I'd also recommend:

- Changing the URL for the repo to https://codeberg.org/puregotk/puregotk
- Archiving the repo once the PR is merged

Follow-up to https://github.com/jwijenbergh/purego/pull/4